### PR TITLE
Update Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,16 @@
 language: node_js
+
 node_js:
-  - 0.8
+  - "iojs"
+  - "node"
+  - "4.1"
+  - "0.12"
+  - "0.8"
+
+matrix:
+  allow_failures:
+  # looks broken on travis-ci itself
+  - node_js: "0.8"
 
 notifications:
   email:


### PR DESCRIPTION
Updates the `.travis.yml` file to include a broader scope of nodejs versions.

Two things I noticed:
- Currently, the option of using nodejs `0.8` seems to be broken in travis itself.
- the latest testable version aka `node` in travis seems to be `5.2.0`
- ~~`lifecycle` seems to fail with nodejs `5.3.0` (not in travis, will check in an independent PR/issue)~~
