### PR TITLE
Warning: Add license to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "name"          : "_lifecycle",
   "description"   : "Lifecycle.js provides conventions and helpers to manage the life cycles of Javascript instances.",
   "keywords"      : ["lifecycle", "lifecyclejs", "json", "util", "server", "client"],
+  "license"       : "MIT",
 
   "url"           : "http://kmalakoff.github.com/lifecycle/",
   "homepage"      : "http://kmalakoff.github.com/lifecycle/",


### PR DESCRIPTION
Removes the warning

```
npm WARN EPACKAGEJSON _lifecycle@1.0.2 No license field.
```

during `npm install` by adding the [MIT license](https://spdx.org/licenses/) that is used in `LICENSE` to [package.json](https://docs.npmjs.com/files/package.json) .
